### PR TITLE
:hammer: fix pulumi-cli-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 # Keycloak Resource Provider
 
 The Keycloak resource provider for Pulumi lets you manage Keycloak resources in your cloud programs. To use
-this package, please [install the Pulumi CLI first](https://www.mailgun.com//).
+this package, please [install the Pulumi CLI first](https://www.pulumi.com/docs/reference/cli/).
 
 ## Installing
 


### PR DESCRIPTION
Swapped out the wrong URL (from mailgun.com to the official pulumi cli how-to docs). 🍀