### PR TITLE
Add local Keycloak test environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,47 @@ You must generate and check in the SDKs on each pull request containing a code c
 
 ## Running Integration Tests
 
-The examples and integration tests in this repository will create and destroy real AWS
-cloud resources while running. Before running these tests, make sure that you have
-[configured Pulumi with AWS](https://pulumi.io/install/aws.html) successfully once before.
+Integration tests require a running Keycloak server. The repository includes a
+Docker Compose environment for manual testing; it is not started by the regular
+test suite or CI.
 
-_TODO: Add any steps you need to take to run integration tests here_
+Start Keycloak from the repository root:
+
+```sh
+docker compose -f docker-compose.test.yml up -d
+
+until curl --fail --silent http://localhost:8080/realms/master > /dev/null; do
+    sleep 1
+done
+```
+
+The environment uses Keycloak 26.6.3 by default. Set `KEYCLOAK_VERSION` to test
+another version, or `KEYCLOAK_PORT` if port 8080 is unavailable:
+
+```sh
+KEYCLOAK_VERSION=26.5.7 KEYCLOAK_PORT=8081 \
+    docker compose -f docker-compose.test.yml up -d
+```
+
+Configure the provider to authenticate as the local bootstrap administrator:
+
+```sh
+export KEYCLOAK_URL=http://localhost:${KEYCLOAK_PORT:-8080}
+export KEYCLOAK_CLIENT_ID=admin-cli
+export KEYCLOAK_USER=keycloak
+export KEYCLOAK_PASSWORD=password
+unset KEYCLOAK_CLIENT_SECRET
+```
+
+You can now run a Pulumi program or focused reproduction against the local
+server. These credentials and the development-mode server are for local testing
+only.
+
+Destroy resources created by the Pulumi program before stopping Keycloak. Then
+remove the local environment and its data:
+
+```sh
+pulumi destroy
+docker compose -f docker-compose.test.yml down --volumes
+```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,19 +35,23 @@ test suite or CI.
 Start Keycloak from the repository root:
 
 ```sh
+export KEYCLOAK_PORT=${KEYCLOAK_PORT:-8080}
 docker compose -f docker-compose.test.yml up -d
 
-until curl --fail --silent http://localhost:8080/realms/master > /dev/null; do
+until curl --fail --silent \
+    http://localhost:${KEYCLOAK_PORT}/realms/master > /dev/null; do
     sleep 1
 done
 ```
 
-The environment uses Keycloak 26.6.3 by default. Set `KEYCLOAK_VERSION` to test
-another version, or `KEYCLOAK_PORT` if port 8080 is unavailable:
+The environment uses Keycloak 26.6.3 by default. Export `KEYCLOAK_VERSION` to
+test another version, or `KEYCLOAK_PORT` if port 8080 is unavailable, before
+starting the environment:
 
 ```sh
-KEYCLOAK_VERSION=26.5.7 KEYCLOAK_PORT=8081 \
-    docker compose -f docker-compose.test.yml up -d
+export KEYCLOAK_VERSION=26.5.7
+export KEYCLOAK_PORT=8081
+docker compose -f docker-compose.test.yml up -d
 ```
 
 Configure the provider to authenticate as the local bootstrap administrator:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,10 @@
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:${KEYCLOAK_VERSION:-26.6.3}
+    command: start-dev
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: keycloak
+      KC_BOOTSTRAP_ADMIN_PASSWORD: password
+      KC_FEATURES: preview,admin-fine-grained-authz:v1
+    ports:
+      - "${KEYCLOAK_PORT:-8080}:8080"


### PR DESCRIPTION
## Summary

- add a lightweight Docker Compose environment for manual provider testing
- document Keycloak startup, readiness, provider authentication, overrides, and cleanup
- replace the unrelated AWS integration-test boilerplate

The environment is intentionally opt-in and is not wired into CI or the generated Makefile.

## Testing

- `docker compose -f docker-compose.test.yml config`
- verified `KEYCLOAK_VERSION` and `KEYCLOAK_PORT` overrides in rendered config
- started Keycloak on port 18082, waited for `/realms/master`, and removed the environment with volumes
